### PR TITLE
Fix "attempt to call global 'set_velocity' (a nil value)"

### DIFF
--- a/mobs_turtles/init.lua
+++ b/mobs_turtles/init.lua
@@ -51,7 +51,7 @@ if mobs.mod and mobs.mod == "redo" then
 		follow = "farming:carrot",
 		on_rightclick = function(self, clicker)
 			self.state = ""
-			set_velocity(self, 0)
+			self:set_velocity(0)
 			self.object:set_animation({x=self.animation.hide_start, y=self.animation.hide_end}, self.animation.speed_normal, 0)
 			minetest.after(5, function() 
 				self.state = "stand"


### PR DESCRIPTION
This fixes this error:
```
2021-10-02 19:43:43: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'mobs_turtles' in callback luaentity_run_simple_callback(): ...test-pvp/.minetest/mods/mobs_water/mobs_turtles/init.lua:54: attempt to call global 'set_velocity' (a nil value)
2021-10-02 19:43:43: ERROR[Main]: stack traceback:
2021-10-02 19:43:43: ERROR[Main]: 	...test-pvp/.minetest/mods/mobs_water/mobs_turtles/init.lua:54: in function 'func'
2021-10-02 19:43:43: ERROR[Main]: 	/usr/share/minetest/builtin/profiler/instrumentation.lua:106: in function </usr/share/minetest/builtin/profiler/instrumentation.lua:100>
```